### PR TITLE
Migration order

### DIFF
--- a/lib/tasks/buffalo_pages.rake
+++ b/lib/tasks/buffalo_pages.rake
@@ -1,6 +1,6 @@
 namespace :buffalo_pages do
   task install: :environment do
-    migrations = Dir["#{BuffaloPages.root}/db/migrate/*"]
+    migrations = Dir["#{BuffaloPages.root}/db/migrate/*"].sort
     target_dir = "#{Rails.root}/db/migrate"
 
     start = DateTime.current


### PR DESCRIPTION
Installing the migrations without `sort` orders them in a seemingly random order. This should sort them before they are given new timestamps during the install. 