### PR TITLE
Reduce the time to insert fields 

### DIFF
--- a/app/controllers/admin/content/pages_controller.rb
+++ b/app/controllers/admin/content/pages_controller.rb
@@ -22,6 +22,16 @@ module Admin
       def build_field_associations
         @object.fields.map(&:build_associations)
       end
+
+      def collection_scope
+        scope = model_class.includes(:fields)
+
+        if model_class.respond_to?(:accessible_by) && defined?(:current_ability) && current_ability.present?
+          scope.accessible_by(current_ability)
+        else
+          scope
+        end
+      end
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,7 @@ class PagesController < ApplicationController
   protected
 
   def set_page
-    @page = Content::Page.includes(:fields, :page_blueprint).find_by(id: params[:page_id])
+    @page = Content::Page.includes(:fields, :page_blueprint, :sites).find_by(id: params[:page_id])
   end
 
   def set_site

--- a/app/models/content/field.rb
+++ b/app/models/content/field.rb
@@ -1,16 +1,11 @@
 module Content
   class Field < ActiveRecord::Base
     TRANSFERABLE_TYPES = ["Content::Fields::Text", "Content::Fields::TextArea", "Content::Fields::CkEditor"].freeze
-    acts_as_list scope: :page
 
     belongs_to :thingable, polymorphic: true
     belongs_to :repeatable, polymorphic: true
     belongs_to :field_blueprint
     belongs_to :page
-
-    validates_associated :field_blueprint, :page
-    validates :variable_name, uniqueness: { scope: "page_id" }, unless: :not_required?
-    validates :variable_name, presence: true, unless: :not_required?
 
     serialize :json_config, JSON
 

--- a/app/models/content/field_blueprint.rb
+++ b/app/models/content/field_blueprint.rb
@@ -21,5 +21,26 @@ module Content
 
       @config ||= JSON.parse(json_config).with_indifferent_access
     end
+
+    def to_field
+      field_type.constantize.new(fields_for_field.merge(field_blueprint_id: id))
+    end
+
+    def sync_field_settings
+      attrs = %w(position json_config variable_name field_type)
+
+      return unless previous_changes.keys.find { |x| attrs.include?(x) }.present?
+
+      # After the check, this value is no longer required, as on the field its `type`
+      attrs.delete("field_type")
+
+      fields.update_all(attributes.slice(*attrs).merge(type: field_type))
+    end
+
+    protected
+
+    def fields_for_field
+      attributes.except("field_type", "created_at", "updated_at", "id", "page_blueprint_id")
+    end
   end
 end

--- a/app/models/content_page_router.rb
+++ b/app/models/content_page_router.rb
@@ -8,7 +8,7 @@ class ContentPageRouter
       # right route, it picks the first page it comes to.
       match "/:slug", to: "pages#show", via: :PAGE
 
-      pages = Content::Page.published
+      pages = Content::Page.includes(:sites).published
       pages.each do |page|
         if page.sites.any?
           page.sites.each do |site|
@@ -18,7 +18,7 @@ class ContentPageRouter
             begin
               get slug, to: "pages#show", defaults: defaults, as: "page_#{slug.parameterize.underscore}"
               post slug, to: "pages#post", defaults: defaults, as: "post_#{slug.parameterize.underscore}" if page.accepts_post
-            rescue ArgumentError => e
+            rescue ArgumentError
               # duplicate route name
             end
           end
@@ -28,7 +28,6 @@ class ContentPageRouter
 
           get slug, to: "pages#show", defaults: defaults, as: "page_#{slug}"
           post slug, to: "pages#post", defaults: defaults, as: "post_#{slug}" if page.accepts_post
-
         end
       end
 

--- a/buffalo_pages.gemspec
+++ b/buffalo_pages.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "acts_as_list"
   spec.add_runtime_dependency "city-state"
   spec.add_runtime_dependency "delayed_paperclip"
+  spec.add_runtime_dependency "activerecord-import", "~> 0.20.2"
 end

--- a/lib/buffalo_pages.rb
+++ b/lib/buffalo_pages.rb
@@ -5,6 +5,7 @@ require "acts_as_list"
 require "city-state"
 require "paperclip"
 require "delayed_paperclip"
+require "activerecord-import"
 
 module BuffaloPages
   if defined?(Rails)


### PR DESCRIPTION
Reduce the time to insert fields into blueprints that have large numbers of pages. 

So now inserting a field into the top of a blueprint (causing all other fields to need to have at least their positions updated), has fallen from around 26,000ms to about 900ms (locally).

Some of this was done by removing acts as list with the pages and updating them from the blueprint instead. The rest came from using a batch insert for new fields and a batch update for existing ones. 

This commit should not break anything. 